### PR TITLE
메인 페이지 스케줄 연동

### DIFF
--- a/AlbaEase/src/Pages/Owner/OwnerMainPage.tsx
+++ b/AlbaEase/src/Pages/Owner/OwnerMainPage.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-import dayjs from "dayjs";
 import Alarm from "../../components/Alarm";
 import AlbaAdd from "../../components/AlbaAdd";
 import Calendar from "../../components/Calendar";
@@ -11,25 +9,23 @@ import SelectRadio from "../../components/SelectRadio";
 import styles from "./OwnerMainPage.module.css";
 
 const OwnerMainPage = () => {
-  const [currentDate, setCurrentDate] = useState(dayjs()); // 현재 날짜 받아오기
-
-  return (
-    <div className={styles.background}>
-      <div className={styles.ownerMainPage}>
-        <Header />
-        <div className={styles.mainContents}>
-          <PartTime />
-          <Calendar currentDate={currentDate} setCurrentDate={setCurrentDate} />
-          <Choice currentDate={currentDate} />
+    return (
+        <div className={styles.background}>
+            <div className={styles.ownerMainPage}>
+                <Header />
+                <div className={styles.mainContents}>
+                    <PartTime />
+                    <Calendar />
+                    <Choice />
+                </div>
+                <div className={styles.bottomContents}>
+                    <Alarm />
+                    <SelectRadio />
+                    <AlbaAdd />
+                </div>
+            </div>
         </div>
-        <div className={styles.bottomContents}>
-          <Alarm />
-          <SelectRadio />
-          <AlbaAdd />
-        </div>
-      </div>
-    </div>
-  );
+    );
 };
 
 export default OwnerMainPage;

--- a/AlbaEase/src/components/Button.module.css
+++ b/AlbaEase/src/components/Button.module.css
@@ -5,10 +5,13 @@
     font-weight: 550;
     font-size: 16px;
 
+    display: flex;
+    justify-content: center;
+    line-height: 35px;
     text-align: center;
     margin: 15px 0;
 
-    width: 245px;
+    width: 230px;
     height: 35px;
     cursor: pointer;
 }

--- a/AlbaEase/src/components/Calendar.module.css
+++ b/AlbaEase/src/components/Calendar.module.css
@@ -69,6 +69,15 @@ p {
     height: 100px; /* 셀 높이 */
 }
 
+.schedules {
+    overflow-y: auto;
+}
+
+.schedules::-webkit-scrollbar {
+    width: 0px;  /* 스크롤 바의 너비를 0으로 설정 */
+    height: 0px; /* 수평 스크롤 바가 있을 경우 높이를 0으로 설정 */
+}
+
 .day {
     padding-top: 5px;
     cursor: pointer;

--- a/AlbaEase/src/components/Calendar.tsx
+++ b/AlbaEase/src/components/Calendar.tsx
@@ -1,18 +1,15 @@
 import styles from "./Calendar.module.css";
 import CalendarSchedule from "./CalendarSchedule";
 import { useState, useEffect } from "react";
-import { Dispatch, SetStateAction } from "react";
-import dayjs, { Dayjs } from "dayjs";
+import dayjs from "dayjs";
+import { useOwnerSchedule } from "../contexts/OwnerScheduleContext";
 import "dayjs/locale/ko";
 
 dayjs.locale("ko");
 
-interface CalendarProps {
-    currentDate: Dayjs;
-    setCurrentDate: Dispatch<SetStateAction<Dayjs>>;
-}
-
-const Calendar: React.FC<CalendarProps> = ({ currentDate, setCurrentDate }) => {
+const Calendar = () => {
+    const { groupedSchedules, currentDate, setCurrentDate } =
+        useOwnerSchedule();
     const [daysArray, setDaysArray] = useState<(number | null)[]>([]); // daysArray 상태 관리
 
     const minDate = dayjs("2025-01-01");
@@ -53,15 +50,12 @@ const Calendar: React.FC<CalendarProps> = ({ currentDate, setCurrentDate }) => {
             newDaysArray.push(null);
 
         setDaysArray(newDaysArray);
-        console.log(daysArray);
         /* 선택한 날짜가 바뀔 때마다 배열 다시 생성
          * (원래는 currentDate.month였는데 number>number로 변경되면
          * useEffect가 변경된 걸 못 잡아내는 오류가 생길 수도 있다고 함,,)
          */
     }, [currentDate]);
 
-    /* console 출력용 */
-    console.log("currentDate is " + currentDate.format());
     const isScrollable = daysArray.length > 35;
 
     return (
@@ -94,40 +88,87 @@ const Calendar: React.FC<CalendarProps> = ({ currentDate, setCurrentDate }) => {
             {/* 날짜 */}
             <div
                 className={`${styles.days} ${
-                    isScrollable ? styles.scroll : " "
+                    isScrollable ? styles.scroll : ""
                 }`}>
-                {daysArray.map((day, index) => (
-                    <div
-                        key={index}
-                        className={`${day ? styles.day : styles.empty} ${
-                            /* day가 null이 아니고 현재 선택한 날짜라면 */
-                            day && currentDate.date() === day
-                                ? styles.isSelected
-                                : ""
-                        }`}
-                        onClick={() => {
-                            if (day) {
-                                setCurrentDate((prevDate) =>
-                                    prevDate.date(day)
-                                ); // 새로운 dayjs 객체 반환 후 설정
-                            }
-                        }} // day가 있으면 날짜, 없으면 빈 칸
-                    >
-                        {day ? day : ""}{" "}
-                        {day ? (
-                            <CalendarSchedule
-                                startTime="09:00"
-                                endTime="13:00"
-                                employeeName="성이름"
-                            />
-                        ) : (
-                            " "
-                        )}
-                    </div>
-                ))}
+                {daysArray.map((day, index) => {
+                    const dateStr = day
+                        ? currentDate.date(day).format("YYYY-MM-DD")
+                        : "";
+
+                    // groupedSchedules에서 해당 날짜의 데이터를 찾기
+                    const schedulesForDate =
+                        groupedSchedules.find(
+                            (schedule) => schedule.date === dateStr
+                        )?.groups || [];
+
+                    return (
+                        <div
+                            key={index}
+                            className={`${day ? styles.day : styles.empty} ${
+                                day && currentDate.date() === day
+                                    ? styles.isSelected
+                                    : ""
+                            }`}
+                            onClick={() => {
+                                if (day) {
+                                    setCurrentDate((prevDate) =>
+                                        prevDate.date(day)
+                                    );
+                                }
+                            }}>
+                            {day ? day : ""}
+                            <div className={styles.schedules}>
+                                {/* groupedSchedules의 그룹이 여러 개일 경우 각각 CalendarSchedule을 생성 */}
+                                {schedulesForDate.map(
+                                    (scheduleGroup, groupIndex) => (
+                                        <CalendarSchedule
+                                            key={groupIndex}
+                                            schedules={[scheduleGroup]}
+                                        />
+                                    )
+                                )}
+                            </div>
+                        </div>
+                    );
+                })}
             </div>
         </div>
     );
 };
 
 export default Calendar;
+
+/*  
+<div
+className={`${styles.days} ${
+    isScrollable ? styles.scroll : " "
+}`}>
+{daysArray.map((day, index) => (
+    <div
+        key={index}
+        className={`${day ? styles.day : styles.empty} ${
+            // day가 null이 아니고 현재 선택한 날짜라면
+            day && currentDate.date() === day
+                ? styles.isSelected
+                : ""
+        }`}
+        onClick={() => {
+            if (day) {
+                setCurrentDate((prevDate) =>
+                    prevDate.date(day)
+                ); // 새로운 dayjs 객체 반환 후 설정
+            }
+        }} // day가 있으면 날짜, 없으면 빈 칸
+    >
+        {day ? day : ""}{" "}
+        {day && selectedList.length !== 0 && groupedSchedules.length > 0 ? (
+            <CalendarSchedule />
+        ) : (
+            " "
+        )}
+    </div>
+))}
+</div>
+</div>
+);
+}; */

--- a/AlbaEase/src/components/CalendarSchedule.module.css
+++ b/AlbaEase/src/components/CalendarSchedule.module.css
@@ -43,4 +43,7 @@
     font-family: "Noto Sans KR", sans-serif;
     font-weight: 400;
     margin-top: 0px;
+    white-space: nowrap;
+    overflow-x: hidden;
+    text-overflow:ellipsis;
 }

--- a/AlbaEase/src/components/CalendarSchedule.tsx
+++ b/AlbaEase/src/components/CalendarSchedule.tsx
@@ -1,21 +1,41 @@
 import styles from "./CalendarSchedule.module.css";
 
-interface CalendarScheduleProps {
+type Schedule = {
     startTime: string;
     endTime: string;
-    employeeName: string;
-}
+    names: string[];
+};
 
-const CalendarSchedule = ({
-    startTime,
-    endTime,
-    employeeName,
-}: CalendarScheduleProps) => {
+// props로 schedules 배열을 받음
+const CalendarSchedule = ({ schedules }: { schedules: Schedule[] }) => {
     return (
         <div className={styles.calendarSchedule}>
-            <div
-                className={styles.workHours}>{`${startTime} ~ ${endTime}`}</div>
-            <div className={styles.names}>{employeeName}</div>
+            {schedules.length > 0 ? (
+                schedules.map((group, index) => {
+                    // "HH:mm:ss"에서 시와 분만 추출
+                    const startTimeFormatted = group.startTime
+                        .split(":")
+                        .slice(0, 2)
+                        .join(":");
+                    const endTimeFormatted = group.endTime
+                        .split(":")
+                        .slice(0, 2)
+                        .join(":");
+
+                    return (
+                        <div key={index} className={styles.scheduleItem}>
+                            <div className={styles.workHours}>
+                                {`${startTimeFormatted} ~ ${endTimeFormatted}`}
+                            </div>
+                            <div className={styles.names}>
+                                {group.names.join(", ")}
+                            </div>
+                        </div>
+                    );
+                })
+            ) : (
+                <div className={styles.noSchedule}>일정이 없습니다.</div>
+            )}
         </div>
     );
 };

--- a/AlbaEase/src/components/Checkbox.tsx
+++ b/AlbaEase/src/components/Checkbox.tsx
@@ -4,8 +4,10 @@ import { useOwnerSchedule } from "../contexts/OwnerScheduleContext";
 
 const Checkbox = () => {
     /* DB 연결 */
-    const { selectedStore } = useOwnerSchedule();
+    const { selectedStore, selectedList, setSelectedList } = useOwnerSchedule();
     const [employeesArray, setEmployeeArray] = useState<string[]>([]);
+    /* 체크박스 선택 관리 */
+    const [isAllSelected, setIsAllSelected] = useState(false);
 
     useEffect(() => {
         const fetchEmployees = async () => {
@@ -18,8 +20,6 @@ const Checkbox = () => {
                     throw new Error("직원 목록 가져오기 실패");
                 }
                 const scheduleData = await res.json();
-
-                console.log(scheduleData);
 
                 // Set을 사용하여 중복된 user.userId 제거
                 const uniqueUserIds = new Set(
@@ -44,12 +44,16 @@ const Checkbox = () => {
         fetchEmployees();
     }, [selectedStore]);
 
+    // 직원 목록이 업데이트되면 selectedList도 자동으로 업데이트
+    useEffect(() => {
+        if (employeesArray.length > 0) {
+            setSelectedList(employeesArray);
+            setIsAllSelected(true);
+        }
+    }, [employeesArray, setSelectedList]);
+
     // 문자열 정렬 (오름차순)
     const sortedArray: string[] = employeesArray.sort();
-
-    /* 체크박스 선택 관리 */
-    const [SelectedList, setSelectedList] = useState<string[]>([]);
-    const [isAllSelected, setIsAllSelected] = useState(false);
 
     /* 전체 선택 및 해제 */
     const handleAllSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -59,7 +63,7 @@ const Checkbox = () => {
             // 선택이 해제되면
             setSelectedList([]);
         }
-        setIsAllSelected(e.target.checked);
+        // setIsAllSelected(e.target.checked);
     };
 
     /* 개별 선택 및 해제 */
@@ -70,7 +74,7 @@ const Checkbox = () => {
                 : [...prev, name];
 
             // 만약 일일이 선택해서 전체 선택이 되면 전체 선택 버튼 활성화
-            setIsAllSelected(newList.length === sortedArray.length);
+            // setIsAllSelected(newList.length === sortedArray.length);
             return newList;
 
             // if (prev.includes(name)) {
@@ -81,7 +85,10 @@ const Checkbox = () => {
         });
     };
 
-    console.log(SelectedList);
+    // isAllSelected 업데이트를 useEffect로 분리하여 렌더링 후 실행
+    useEffect(() => {
+        setIsAllSelected(selectedList.length === sortedArray.length);
+    }, [selectedList, sortedArray]);
 
     return (
         <div className={styles.checkbox}>
@@ -98,7 +105,7 @@ const Checkbox = () => {
                     <input
                         type="checkbox"
                         onChange={() => handleSingleSelect(employeeName)}
-                        checked={SelectedList.includes(employeeName)}
+                        checked={selectedList.includes(employeeName)}
                     />
                     {employeeName}
                 </label>

--- a/AlbaEase/src/components/Choice.tsx
+++ b/AlbaEase/src/components/Choice.tsx
@@ -1,20 +1,33 @@
-import { Dayjs } from "dayjs";
+import { useOwnerSchedule } from "../contexts/OwnerScheduleContext";
 import ChoiceSchedule from "./ChoiceSchedule";
 import Button from "./Button";
 import styles from "./Choice.module.css";
 
-interface ChoiceProps {
-    currentDate: Dayjs;
-}
+const Choice = () => {
+    const { currentDate, groupedSchedules } = useOwnerSchedule();
 
-const Choice: React.FC<ChoiceProps> = ({ currentDate }) => {
+    // 선택된 날짜를 YYYY-MM-DD 형식으로 변환
+    const dateStr = currentDate.format("YYYY-MM-DD");
+
+    // groupedSchedules에서 선택된 날짜의 데이터를 찾기
+    const schedulesForDate = groupedSchedules
+        .filter((schedule) => schedule.date === dateStr)  // 해당 날짜를 찾음
+        .flatMap((schedule) =>
+            schedule.groups.map((group) => ({
+                startTime: group.startTime.split(":").slice(0, 2).join(":"), // "HH:mm:ss" -> "HH:mm"
+                endTime: group.endTime.split(":").slice(0, 2).join(":"),
+                names: group.names,
+            }))
+        );
     return (
         <div className={styles.choice}>
             <div className={styles.date}>
                 {currentDate.format("YYYY년 MM월 DD일")}
             </div>
-            <div>
-                <ChoiceSchedule />
+            <div className={styles.scheduleContainer}>
+                {schedulesForDate.length > 0 && (
+                    <ChoiceSchedule schedules={schedulesForDate} />
+                )}
             </div>
             <Button children={"근무 등록하기"} />
         </div>

--- a/AlbaEase/src/components/ChoiceSchedule.module.css
+++ b/AlbaEase/src/components/ChoiceSchedule.module.css
@@ -1,15 +1,22 @@
+.box {
+    margin-bottom: 0;
+}
+
 .choiceSchedule {
+    display: flex;
+    flex-direction: column;
     justify-content: center;
     width: 230px;
-    height: 100%;
-    margin: 20px 0;
-    background-color: #FFFFFF;
+    height: auto;
+    margin: 15px 0;
+    margin-bottom: 10px;
+    background-color: #ffffff;
     border: solid 1.5px #009963;
     border-radius: 3px;
 }
 
 .workhours {
-    background-color: rgba(0,153,99, 0.2);
+    background-color: rgba(0, 153, 99, 0.2);
     font-weight: 700;
     font-size: 16px;
     padding: 5px 0;

--- a/AlbaEase/src/components/ChoiceSchedule.tsx
+++ b/AlbaEase/src/components/ChoiceSchedule.tsx
@@ -1,35 +1,36 @@
 import styles from "./ChoiceSchedule.module.css";
 
-const ChoiceSchedule = () => {
-    /* 얘네를 하나의 객체에 넣고 빼서 쓸 수 있게 하면 좋을 듯??
-     * 나중에 DB에서 가져와서 할당해야 함 */
-    const startTime: string = "13:00";
-    const endTime: string = "18:00";
-    const employeeNames: string[] = ["이름1", "이름2", "이름3"];
+type Schedule = {
+    startTime: string;
+    endTime: string;
+    names: string[];
+};
 
+interface ChoiceScheduleProps {
+    schedules: Schedule[];
+}
+
+const ChoiceSchedule = ({ schedules }: ChoiceScheduleProps) => {
     return (
-        <div className={styles.choiceSchedule}>
-            <div
-                className={styles.workhours}>{`${startTime} - ${endTime}`}</div>
-            <ul className={styles.names}>
-                {employeeNames.map((employeeName, index) => (
-                    <li key={index} className={styles.employeeName}>
-                        {employeeName}
-                    </li>
-                ))}
-            </ul>
+        <div className={styles.box}>
+            {schedules.map((schedule, index) => (
+                <div className={styles.choiceSchedule}>
+                    <div key={index} className={styles.scheduleBlock}>
+                        <div className={styles.workhours}>
+                            {`${schedule.startTime} - ${schedule.endTime}`}
+                        </div>
+                        <ul className={styles.names}>
+                            {schedule.names.map((name, i) => (
+                                <li key={i} className={styles.employeeName}>
+                                    {name}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+            ))}
         </div>
     );
 };
 
 export default ChoiceSchedule;
-
-/*
-            <div className={styles.names}>
-                {employeeNames.map((employeeName, index) => (
-                    <div key={index} className={styles.employeeName}>
-                        {employeeName}
-                    </div>
-                ))}
-            </div>
-*/

--- a/AlbaEase/src/contexts/OwnerScheduleContext.tsx
+++ b/AlbaEase/src/contexts/OwnerScheduleContext.tsx
@@ -6,12 +6,13 @@ import {
     useMemo,
     useEffect,
 } from "react";
+import dayjs, { Dayjs } from "dayjs";
 
 /* 넘길 수 있는 데이터
  * 1. 알바생의 아이디, 시작 시간과 종료 시간 (schedule 컴포넌트들에 사용)
  * 2. 선택된 알바생 목록 (checkbox와 schedule 컴포넌트들에 사용)
  * 3. 전체 스케줄 (schedule 컴포넌트들에 사용) > 2번 활용해서 필터링
- * 즉, ChoiceSchedule, CalendarSchedule, checkbox 등에서 공유할 예정!!
+ * 4. 가게 정보 (가게명, 매장 코드)
  *
  * ## 참고: 데이터 가져오는 방법 ##
  * Provider 내부에서 fetch() 이용해 하위 컴포넌트는 불러다가 쓰도록 함
@@ -19,11 +20,17 @@ import {
  */
 
 /* 새 타입 명시 */
-interface OwnerSchedule {
-    user_id: number; // 알바생 아이디
+interface Users {
+    userId: number; // 알바생 아이디
     name: string; // 알바생 이름
+}
+
+interface OwnerSchedule {
+    user: Users; // 객체로 사용
     startTime: string; // 시작 시간 (13:00)
     endTime: string; // 종료 시간 (21:00)
+    repeatDays: string; // 반복 요일
+    workDates: Dayjs; // 근무 날짜
 }
 
 interface Store {
@@ -34,15 +41,21 @@ interface Store {
 
 /* 공유할 context type */
 interface OwnerScheduleContextType {
-    stores: Store[];
+    stores: Store[]; // 전체 매장 목록 -> 나중에 사용자 따라서 다른 걸 받아오도록 해야 됨!
     setStores: React.Dispatch<React.SetStateAction<Store[]>>;
     selectedStore: number;
     setSelectedStore: React.Dispatch<React.SetStateAction<number>>;
     selectedList: string[]; // 선택된 알바생 목록
     setSelectedList: React.Dispatch<React.SetStateAction<string[]>>;
-    ownerSchedules: OwnerSchedule[]; // 전체 일정 목록
+    ownerSchedules: OwnerSchedule[]; // 선택 매장 스케줄 목록
     setOwnerSchedules: React.Dispatch<React.SetStateAction<OwnerSchedule[]>>;
-    groupedSchedules: { startTime: string; endTime: string; names: string[] }[]; // 같은 시간대에 일하는 알바생 그룹
+    groupedSchedules: {
+        date: string;
+        groups: { startTime: string; endTime: string; names: string[] }[];
+    }[];
+    // 날짜와 같은 시간대에 일하는 알바생 그룹
+    currentDate: Dayjs;
+    setCurrentDate: React.Dispatch<React.SetStateAction<Dayjs>>;
 }
 
 const OwnerScheduleContext = createContext<
@@ -58,6 +71,7 @@ export const OwnerScheduleProvider = ({
     const [selectedStore, setSelectedStore] = useState<number>(0);
     const [selectedList, setSelectedList] = useState<string[]>([]);
     const [ownerSchedules, setOwnerSchedules] = useState<OwnerSchedule[]>([]);
+    const [currentDate, setCurrentDate] = useState<Dayjs>(dayjs());
 
     /* DB에서 가게 목록 가져오기 */
     useEffect(() => {
@@ -78,8 +92,6 @@ export const OwnerScheduleProvider = ({
                     storeCode: store.storeCode,
                 }));
 
-                console.log("가게 목록 (storeId만): ", filteredStores);
-                console.log("가게 목록: ", filteredStores);
                 setStores(filteredStores);
                 if (filteredStores.length > 0) {
                     setSelectedStore(filteredStores[0].storeId); // 기본 선택값 설정
@@ -99,8 +111,11 @@ export const OwnerScheduleProvider = ({
             if (!selectedStore) return; // 선택된 가게가 없으면 실행하지 않음
 
             try {
-                const res = await fetch(`http://localhost:8080/schedules/store/${selectedStore}`);
+                const res = await fetch(
+                    `http://localhost:8080/schedules/store/${selectedStore}`
+                );
                 const data: OwnerSchedule[] = await res.json();
+                console.log(data);
                 setOwnerSchedules(data);
             } catch (error) {
                 console.error(
@@ -110,45 +125,138 @@ export const OwnerScheduleProvider = ({
             }
         };
 
-        console.log(selectedStore);
         fetchSchedules();
     }, [selectedStore]);
 
+    /* 스케줄 그룹화 */
     const groupedSchedules = useMemo(() => {
         /* selectedList에 있는 알바생들의 일정만 filteredSchedules에 저장 */
-        const filteredSchedules = ownerSchedules.filter((schedule) => {
-            selectedList.includes(schedule.name);
-        });
+        const filteredSchedules = ownerSchedules.filter((schedule) =>
+            selectedList.includes(schedule.user.name)
+        );
 
-        /* 알바생들을 그룹화한 것을 모을 배열 생성 */
-        const groupsArray: {
-            startTime: string;
-            endTime: string;
-            names: string[];
-        }[] = [];
+        // console.log("스케줄", ownerSchedules);
+        // console.log("선택 리스트", selectedList);
+        // console.log("필터링 된 스케줄", filteredSchedules);
 
-        /* 기존에 존재하는 그룹의 시작과 종료 시간이 동일하다면 그룹에 추가
-         * 그렇지 않다면 새로운 그룹을 만듦 */
+        /* currentDate를 기준으로 한 달의 시작일과 종료일을 계산 */
+        const startOfMonth = currentDate.startOf("month");
+        const endOfMonth = currentDate.endOf("month");
+
+        /* 각 일자별 배열 */
+        const monthDates: Dayjs[] = [];
+        let currentDateInMonth = startOfMonth;
+
+        /* 해당 월의 시작부터 끝까지 배열에 저장 */
+        while (
+            currentDateInMonth.isBefore(endOfMonth, "day") ||
+            currentDateInMonth.isSame(endOfMonth, "day")
+        ) {
+            monthDates.push(currentDateInMonth);
+            currentDateInMonth = currentDateInMonth.add(1, "day");
+        }
+
+        /* 날짜별 스케줄을 저장하는 객체
+         * 날짜를 키로 하고 각 날짜에 시작, 종료, 알바생 명단을 저장 */
+        const scheduleMap = monthDates.reduce((acc, date) => {
+            acc[date.format("YYYY-MM-DD")] = []; // 날짜별 빈 배열로 초기화
+            return acc;
+            // 형식은 날짜(string), 일정 기록하는 객체(시작 시간, 끝 시간, 알바생 명단)
+        }, {} as Record<string, { startTime: string; endTime: string; names: string[] }[]>);
+
         filteredSchedules.forEach((schedule) => {
-            const existingGroup = groupsArray.find(
-                (group) =>
-                    group.startTime === schedule.startTime &&
-                    group.endTime === schedule.endTime
-            );
+            // repeat_days가 null인 경우, workDate를 기준으로 날짜 매칭
+            if (schedule.repeatDays === null) {
+                const workDate = dayjs(schedule.workDates); // workDate를 Dayjs로 변환
+                if (workDate.month() === currentDate.month()) {
+                    // 스케줄의 월이 현재 날짜의 월과 같으면
+                    const dateStr = workDate.format("YYYY-MM-DD"); // 해당 날짜에 스케줄 추가
+                    const existingGroup = scheduleMap[dateStr].find(
+                        // 동일한 스케줄 있는지 찾음
+                        (group: any) =>
+                            group.startTime === schedule.startTime &&
+                            group.endTime === schedule.endTime
+                    );
 
-            if (existingGroup) {
-                existingGroup.names.push(schedule.name);
-            } else {
-                groupsArray.push({
-                    startTime: schedule.startTime,
-                    endTime: schedule.endTime,
-                    names: [schedule.name],
+                    if (existingGroup) {
+                        // 이미 존재하는 그룹 있으면 이름을 추가
+                        existingGroup.names.push(schedule.user.name);
+                    } else {
+                        // 이전에 해당 스케줄 그룹이 없으면 새로 그룹 추가
+                        scheduleMap[dateStr].push({
+                            startTime: schedule.startTime,
+                            endTime: schedule.endTime,
+                            names: [schedule.user.name],
+                        });
+                    }
+                }
+            }
+
+            // repeat_days가 null이 아닌 경우, 요일을 기준으로 반복되는 스케줄 계산
+            /* 시작 날짜 가져와서 그날부터 추가하도록 수정해야 됨 */
+            else {
+                const dayOfWeekStrings = [
+                    "일",
+                    "월",
+                    "화",
+                    "수",
+                    "목",
+                    "금",
+                    "토",
+                ];
+
+                // 반복 요일 받아오기
+                // repeatDays가 null 또는 undefined일 경우 빈 배열로 처리
+                const repeatDaysArray = (schedule.repeatDays || "").split(","); // repeatDays를 ','로 구분하여 배열로 변환
+
+                monthDates.forEach((date) => {
+                    const dayOfWeek = dayOfWeekStrings[date.day()]; // 해당 날짜의 요일, 2025-02-13의 경우 "목"
+
+                    // 반복 요일 배열에 해당 날짜의 요일이 포함되어 있으면 스케줄 추가
+                    if (repeatDaysArray.includes(dayOfWeek)) {
+                        const dateStr = date.format("YYYY-MM-DD");
+
+                        // scheduleMap[dateStr]가 존재하지 않으면 빈 배열로 초기화
+                        if (!scheduleMap[dateStr]) {
+                            scheduleMap[dateStr] = [];
+                        }
+
+                        // 해당 날짜에 이미 같은 시간대의 스케줄이 있다면, 알바생 이름 추가
+                        const existingGroup = scheduleMap[dateStr].find(
+                            (group) =>
+                                group.startTime === schedule.startTime &&
+                                group.endTime === schedule.endTime
+                        );
+
+                        if (existingGroup) {
+                            existingGroup.names.push(schedule.user.name);
+                        } else {
+                            scheduleMap[dateStr].push({
+                                startTime: schedule.startTime,
+                                endTime: schedule.endTime,
+                                names: [schedule.user.name],
+                            });
+                        }
+                    }
                 });
             }
         });
 
-        return groupsArray;
-    }, [selectedList, ownerSchedules]); // 선택된 알바생 목록이 변경되거나 데이터베이스에 변경이 있을 때만 재계산
+        // 날짜별로 그룹화된 스케줄을 배열로 변환
+        const result = Object.entries(scheduleMap).map(([dateStr, groups]) => ({
+            date: dateStr,
+            groups: groups.sort((a, b) =>
+                a.startTime.localeCompare(b.startTime)
+            ), // startTime 기준 정렬
+        }));
+
+        console.log("groupedSchedules 결과: ", result);
+        return result;
+    }, [
+        JSON.stringify(selectedList),
+        JSON.stringify(ownerSchedules),
+        currentDate,
+    ]); // 선택된 알바생 목록이 변경되거나 데이터베이스에 변경이 있을 때만 재계산
 
     /* ## 참고: 데이터 가져오는 방법 예시 ##
     // 데이터 가져오기 - 한 번만 실행
@@ -179,6 +287,8 @@ export const OwnerScheduleProvider = ({
                 ownerSchedules,
                 setOwnerSchedules,
                 groupedSchedules,
+                currentDate,
+                setCurrentDate,
             }}>
             {children}
         </OwnerScheduleContext.Provider>


### PR DESCRIPTION
### **1. CalendarSchedule과 ChoiceSchedule에 뜨는 데이터들을 DB에서 연동**
- 기존 데이터는 하드 코딩 된 것들을 가져오는 형식이었는데, DB에서 적절한 데이터를 추출해서 출력하도록 함
- OwnerScheduleContext 에서 데이터 전체 관리
- Choice와 Calendar의 CurrentDate도 위의 context에서 관리하는 걸 받아오도록 함

-> 추후 fetch로 받아오고 있는 DB 데이터들을 axios로 받아오도록 변경할 예정